### PR TITLE
Add missing link to fields overview.mdx

### DIFF
--- a/docs/fields/overview.mdx
+++ b/docs/fields/overview.mdx
@@ -46,6 +46,7 @@ export const Page: CollectionConfig = {
 - [Date](/docs/fields/date) - date / time field that saves a timestamp
 - [Email](/docs/fields/email) - validates the entry is a properly formatted email
 - [Group](/docs/fields/group) - nest fields within an object
+- [JSON](/docs/fields/json) - nest fields within an object
 - [Number](/docs/fields/number) - field that enforces that its value be a number
 - [Point](/docs/fields/point) - geometric coordinates for location data
 - [Radio](/docs/fields/radio) - radio button group, allowing only one value to be selected


### PR DESCRIPTION
## Description

Add link to JSON field type in list of "field types" on fields overview documentation page.

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing test suite passes locally with my changes
- [x] I have made corresponding changes to the documentation
